### PR TITLE
fix(ci): AzureSignTool 5.0.0 — compatible .NET 8 (4.0.1 requiert .NET…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
           env.AZURE_CLIENT_SECRET != ''
         shell: pwsh
         run: |
-          dotnet tool install --global AzureSignTool --version 4.0.1
+          dotnet tool install --global AzureSignTool --version 5.0.0
           $installer = Get-ChildItem "dist\installer\Gestio-Setup-*.exe" | Select-Object -First 1
           if (-not $installer) { Write-Error "Installeur introuvable"; exit 1 }
 


### PR DESCRIPTION
… 6 absent) #23