### PR TITLE
fix(launcher): corriger chemin app_dir et import duplique #23

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Shim de compatibilite — delegue a launcher/launcher.py."""
+import sys
+from pathlib import Path
+
+# Ajouter launcher/ dans sys.path pour les imports absolus
+_LAUNCHER_DIR = Path(__file__).parent / "launcher"
+if str(_LAUNCHER_DIR) not in sys.path:
+    sys.path.insert(0, str(_LAUNCHER_DIR))
+
+from launcher_core import resolve_app_dir, resolve_uv_path  # noqa: E402
+from launcher_ui import Launcher  # noqa: E402
+
+
+def main() -> None:
+    import multiprocessing
+    if getattr(sys, 'frozen', False):
+        multiprocessing.freeze_support()
+    Launcher(resolve_app_dir(), resolve_uv_path()).run()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/launcher/launcher.py
+++ b/launcher/launcher.py
@@ -10,9 +10,17 @@ Point d'entree minimal : resout les chemins et delegue a launcher_ui.
 
 import sys
 import multiprocessing
+from pathlib import Path
 
-from .launcher_core import resolve_app_dir, resolve_uv_path
-from .launcher_ui import Launcher
+# Ajouter le dossier launcher/ dans sys.path pour que
+# launcher_core et launcher_ui soient importables sans package parent
+# (necesaire pour PyInstaller onefile et execution directe)
+_LAUNCHER_DIR = Path(__file__).parent
+if str(_LAUNCHER_DIR) not in sys.path:
+    sys.path.insert(0, str(_LAUNCHER_DIR))
+
+from launcher_core import resolve_app_dir, resolve_uv_path  # noqa: E402
+from launcher_ui import Launcher  # noqa: E402
 
 
 def main() -> None:
@@ -27,4 +35,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/launcher/launcher_core.py
+++ b/launcher/launcher_core.py
@@ -28,7 +28,8 @@ def resolve_app_dir() -> Path:
         installed = Path(sys.executable).parent / "app"
         if installed.exists():
             return installed
-    return Path(__file__).parent
+    # launcher_core.py est dans launcher/ — remonter d'un niveau vers la racine
+    return Path(__file__).parent.parent
 
 
 def resolve_uv_path() -> str:

--- a/launcher/launcher_ui.py
+++ b/launcher/launcher_ui.py
@@ -16,12 +16,7 @@ import webbrowser
 from pathlib import Path
 from tkinter import scrolledtext
 
-from .launcher_core import (
-    PORT, STARTUP_TIMEOUT,
-    build_streamlit_cmd, build_streamlit_env,
-    find_chrome, is_port_in_use, kill_port,
-    sync_dependencies,
-)
+from launcher_core import (
     PORT, STARTUP_TIMEOUT,
     build_streamlit_cmd, build_streamlit_env,
     find_chrome, is_port_in_use, kill_port,


### PR DESCRIPTION
- launcher_core.py: resolve_app_dir() remonte .parent.parent (launcher/ -> racine)
- launcher_ui.py: supprimer import duplique (IndentationError)
- launcher.py + launcher/launcher.py: imports absolus via sys.path (pas d'imports relatifs)